### PR TITLE
Amendment 1 to allow the Board to establish Succession order

### DIFF
--- a/Board.md
+++ b/Board.md
@@ -63,7 +63,7 @@
     - To report to the Vice President and the Board, any issues in the operation of the VGDC, and
     - To maintain any additional records necessary for the operation of the VGDC.
 3. If the position of Head of Operations may be Vacant, then the Vice President may exercise the above duties and authorities.
-4. While the positions of President and Vice President may both be Vacant, the Head of Operations shall preside over and have the authority to convene the Board, and shall instruct the Board to issue joint ballots for President and Vice President and may also instruct the board to issue ballots for the position of Treasurer, and any other board positions, as those positions may be vacant.
+4. [Repealed, Amendment 1]
 
 ## §7 Meetings of the Board.
 1. A meeting of the Board shall be convened at the discretion of the President, or when one half of the Board may request such,

--- a/Executive.md
+++ b/Executive.md
@@ -76,7 +76,7 @@
     - No person shall become Treasuer until with respect to the president's authority to appoint a Treasurer, one of the following has occured:
         - The President has ordered ballots be issued for the position of Treasurer, and the ballots were returned with no result,
         - The President has announced intent to appoint a Treasurer, but has not done so in a reasonable period of time that may be set by regulation, or
-        - The President has waived both of the above authorities with respect ot the vacancy.
+        - The President has waived both of the above authorities with respect to the vacancy.
 
 ## §6 Removal of Board Members and Executives
 

--- a/Executive.md
+++ b/Executive.md
@@ -76,7 +76,7 @@
     - No person shall become Treasuer until with respect to the president's authority to appoint a Treasurer, one of the following has occured:
         - The President has ordered ballots be issued for the position of Treasurer, and the ballots were returned with no result,
         - The President has announced intent to appoint a Treasurer, but has not done so in a reasonable period of time that may be set by regulation, or
-        - The Preside thas waived both of the above authorities with respect ot the vacancy.
+        - The President has waived both of the above authorities with respect ot the vacancy.
 
 ## §6 Removal of Board Members and Executives
 

--- a/Executive.md
+++ b/Executive.md
@@ -35,6 +35,9 @@
     - To instruct the Vice President to assume, on a temporary basis, any or all of the authorities herein and to voluntarily vacate the position to the Vice President
 4. Whenever the Position of Vice President or Treasurer may be vacant, the President may appoint, on a temporary basis, a replacement for that position, or may instruct the board to issue ballots for the positions which shall be returned 48 hours from the date of issue.
 5. The President shall be responsible for any and all interactions with the UWSA, and shall be responsible for ensuring that the VGDC meets the requirements for a Student Group with the UWSA and remains such.
+6. The Board may by regulation set the order of succession for the position of President of the VGDC if both that position and the position of Vice President are vacant.
+    - Until such time as such a regulation shall be made, the succession order for the Position of President shall be: Vice President, Treasurer, Head of Operations, Head of Community, Head of Events, Head of Development.
+    - Where the vacancy for President is the result of a tie on the joint ballot for President and Vice President, no person shall become President under this clause until the Board has succesfully resolved the tie
 
 ## §3 Vice President
 
@@ -67,6 +70,13 @@
     - To preside over the Board while it decides ties on the Joint Ballot for President and Vice President,
 3. Not later than the 31st of March, or as the Board may otherwise demand, the Board shall issue ballots for the position of Treasurer, in which persons who voluntarily nominate themselves for the position and meet the requirements of the position as set by this constitution and by any reasonable, non-discriminatory, restrictions adopted by the Board, shall be candidates for the position presented on the ballot.
 4. On return of the ballot, the person who has the most number of votes for the position shall be elected Treasurer. If two or more persons may be tied for the most number of votes, then the Board, absent the treasurer, shall choose, from among those tied, the person who shall be hold the position of Treasurer. 
+5. The Board may by regulation set the order of succession for the position of Treasurer of the VGDC if that position may be vacant.
+    - Until such time as such a regulation shall be made, the succession order for the Position of Treasurer shall be: Head of Events, Head of Development, Head of Operations, Head of Community.
+    - Where the vacancy for Tresurer is the result of a tie on a ballot for the position of Treasurer, no person shall become Treasurer under this clause until the Board has succesfully resolved the tie.
+    - No person shall become Treasuer until with respect to the president's authority to appoint a Treasurer, one of the following has occured:
+        - The President has ordered ballots be issued for the position of Treasurer, and the ballots were returned with no result,
+        - The President has announced intent to appoint a Treasurer, but has not done so in a reasonable period of time that may be set by regulation, or
+        - The Preside thas waived both of the above authorities with respect ot the vacancy.
 
 ## §6 Removal of Board Members and Executives
 


### PR DESCRIPTION
# Regulation Proposing to Amend the Constitution of the VGDC to allow the Board to set succession by regulation

1. The Board on First Reading and Final Consideration do hereby propose to adopt the following amendment to the constitution

## Head of Operations Special Power Repealed

2. Article III, Section 6, Clause 4 is hereby repealed.

## Succession Order For President may be set by the Board

3. A new clause is hereby added to Article II, Section 2, following clause 5, numbered as clause 6, which shall read as follows:
- The Board may by regulation set the order of succession for the position of President of the VGDC if both that position and the position of Vice President are vacant.
4. A new subclause of clause 6 of Article II, Section 2, is hereby added, which shall read as follows:
- Until such time as such a regulation shall be made, the succession order for the Position of President shall be: Vice President, Treasurer, Head of Operations, Head of Community, Head of Events, Head of Development.
5. A new subclause of clause 6 of Article II, Section 2, is hearby added, which shall read as follows:
- Where the vacancy for President is the result of a tie on the joint ballot for President and Vice President, no person shall become President under this clause until the Board has succesfully resolved the tie

## Succession Order for Treasurer may be set by the Board

6. A new clause is hereby added to Article II, Section 5, following clause 4, numbered as clause 5, which shall read as follows:
- The Board may by regulation set the order of succession for the position of Treasurer of the VGDC if that position may be vacant.
7. A new subclause of clause 5 of Article II, Section 5, is hereby added, which shall read as follows:
- Until such time as such a regulation shall be made, the succession order for the Position of Treasurer shall be: Head of Events, Head of Development, Head of Operations, Head of Community. 
8. A new subclause of clause 5 of Article II, Section 5, is hearby added, which shall read as follows:
- Where the vacancy for Tresurer is the result of a tie on a ballot for the position of Treasurer, no person shall become Treasurer under this clause until the Board has succesfully resolved the tie.
9. A new subclause of clause 5 of Article II, Section 5, is hearby added, which shall read as follows:
- No person shall become Treasuer until with respect to the president's authority to appoint a Treasurer, one of the following has occured:
  - The President has ordered ballots be issued for the position of Treasurer, and the ballots were returned with no result,
  - The President has announced intent to appoint a Treasurer, but has not done so in a reasonable period of time that may be set by regulation, or
  - The President has waived both of the above authorities with respect to the vacancy.